### PR TITLE
Scale down related improvements

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -339,9 +339,6 @@ func (c *Controller) getDesiredWorkers(
 	}
 
 	if idleWorkers != 0 {
-		if queueMessages == 0 {
-			return keepInRange(minWorkers, maxWorkers, 0)
-		}
 		desiredWorkers := currentWorkers - idleWorkers
 		return keepInRange(minWorkers, maxWorkers, desiredWorkers)
 	}


### PR DESCRIPTION
- Prevent workers which are doing the jobs to scale down.
- Use p99 for calculating the `NumberOfEmptyReceive` as this is the only value that can go to reach `1` and if used with `ApproximateNumberOfMessagesVisible` it can be used to determine how much to scale down.
- Scale down now will become a single type of scale down which is scaling down to minimum. Massive scale downs. There is nothing in between as this is the best we have come so far using the  AWS metric keeping the reliability of workers in check.