### PR TITLE
Scale down whenever possible if the worker is defined as disruptable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ spec:
   targetMessagesPerWorker: 2
   deploymentName: example-deployment
   queueURI: https://sqs.ap-south-1.amazonaws.com/{{aws_account_id}}/{{queue_prefix-queue_name-queue_suffix}}
+  idempotent: false
 ```
+
+**Note:** idempotent flag specfies the worker is idempotent. WPA scales down to only minimum when a worker is not idempotent. When a worker is indempotent it can scale down to a value greater than minimum also since the worker is idempotent and can take the disruption caused due to scale down. [MoreInfo](https://github.com/practo/k8s-worker-pod-autoscaler/issues/50).
 
 ## WPA Controller
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ spec:
   targetMessagesPerWorker: 2
   deploymentName: example-deployment
   queueURI: https://sqs.ap-south-1.amazonaws.com/{{aws_account_id}}/{{queue_prefix-queue_name-queue_suffix}}
-  idempotent: false
+  disruptable: false
 ```
 
-**Note:** idempotent flag specfies the worker is idempotent. WPA scales down to only minimum when a worker is not idempotent. When a worker is indempotent it can scale down to a value greater than minimum also since the worker is idempotent and can take the disruption caused due to scale down. [MoreInfo](https://github.com/practo/k8s-worker-pod-autoscaler/issues/50).
+**Note:** `disruptable` flag specifies the worker can tolerate the disruption due to scale down. WPA scales down to only minimum when a worker is not disruptable and when a worker is disruptable it can scale down to a value greater than minimum. [MoreInfo](https://github.com/practo/k8s-worker-pod-autoscaler/issues/50).
 
 ## WPA Controller
 

--- a/artifacts/examples/example-wpa.yaml
+++ b/artifacts/examples/example-wpa.yaml
@@ -6,6 +6,6 @@ spec:
   minReplicas: 0
   maxReplicas: 10
   targetMessagesPerWorker: 2
-  idempotent: false
+  disruptable: false
   deploymentName: example-deployment
   queueURI: https://sqs.ap-south-1.amazonaws.com/{{aws_account_id}}/{{queue_prefix-queue_name-queue_suffix}}

--- a/artifacts/examples/example-wpa.yaml
+++ b/artifacts/examples/example-wpa.yaml
@@ -6,5 +6,6 @@ spec:
   minReplicas: 0
   maxReplicas: 10
   targetMessagesPerWorker: 2
+  idempotent: false
   deploymentName: example-deployment
   queueURI: https://sqs.ap-south-1.amazonaws.com/{{aws_account_id}}/{{queue_prefix-queue_name-queue_suffix}}

--- a/pkg/apis/workerpodautoscaler/v1alpha1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1alpha1/types.go
@@ -23,6 +23,7 @@ type WorkerPodAutoScalerSpec struct {
 	QueueURI                string `json:"queueURI"`
 	DeploymentName          string `json:"deploymentName"`
 	TargetMessagesPerWorker *int32 `json:"targetMessagesPerWorker"`
+	Idempotent              bool   `json:"idempotent"`
 }
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource

--- a/pkg/apis/workerpodautoscaler/v1alpha1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1alpha1/types.go
@@ -23,7 +23,7 @@ type WorkerPodAutoScalerSpec struct {
 	QueueURI                string `json:"queueURI"`
 	DeploymentName          string `json:"deploymentName"`
 	TargetMessagesPerWorker *int32 `json:"targetMessagesPerWorker"`
-	Idempotent              bool   `json:"idempotent"`
+	Disruptable             bool   `json:"disruptable"`
 }
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -296,7 +296,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		idleWorkers,
 		*workerPodAutoScaler.Spec.MinReplicas,
 		*workerPodAutoScaler.Spec.MaxReplicas,
-		workerPodAutoScaler.Spec.Idempotent,
+		workerPodAutoScaler.Spec.Disruptable,
 	)
 	klog.Infof("%s: messages: %d, idle: %d, desired: %d", queueName, queueMessages, idleWorkers, desiredWorkers)
 
@@ -362,7 +362,7 @@ func (c *Controller) getDesiredWorkers(
 	idleWorkers int32,
 	minWorkers int32,
 	maxWorkers int32,
-	idempotent bool) int32 {
+	disruptable bool) int32 {
 
 	tolerance := 0.1
 	usageRatio := float64(queueMessages) / float64(targetMessagesPerWorker)
@@ -383,7 +383,7 @@ func (c *Controller) getDesiredWorkers(
 		}
 
 		desiredWorkers := int32(math.Ceil(usageRatio * float64(currentWorkers)))
-		if !idempotent && desiredWorkers < currentWorkers {
+		if !disruptable && desiredWorkers < currentWorkers {
 			return currentWorkers
 		}
 		return convertDesiredReplicasWithRules(desiredWorkers, minWorkers, maxWorkers)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -296,7 +296,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		idleWorkers,
 		*workerPodAutoScaler.Spec.MinReplicas,
 		*workerPodAutoScaler.Spec.MaxReplicas,
-		*workerPodAutoScaler.Spec.Idempotent,
+		workerPodAutoScaler.Spec.Idempotent,
 	)
 	klog.Infof("%s: messages: %d, idle: %d, desired: %d", queueName, queueMessages, idleWorkers, desiredWorkers)
 


### PR DESCRIPTION
Fixes https://github.com/practo/k8s-worker-pod-autoscaler/issues/50

Adds `idempotent:` flag in the WPA spec.

- `disruptable: false`
```
WPA will scale down only to min when all workers have stopped processing.
```

- `disruptable: true`
```
WPA will scale down to values between min and current if the calculated desired no of replicas falls to a lower number.
```

Default still is `disruptable: false`.