### PR TITLE
Added global verbosity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Flags:
       --sqs-short-poll-interval int         the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
       --wpa-default-max-disruption string   it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
       --wpa-threads int                     wpa threadiness, number of threads to process wpa resources (default 10)
+
+Global Flags:
+  -v, --v Level   number for the log level verbosity
 ```
 
 If you need to enable multiple queue support, you can add queues comma separated in `--queue-services`. For example, if beanstalkd is started and there is no WPA beanstalk resource present, then nothing happens, until a beanstalk WPA resource is created. Queue poller service only operates on the filtered WPA objects.

--- a/artifacts/deployment-template.yaml
+++ b/artifacts/deployment-template.yaml
@@ -42,6 +42,7 @@ spec:
        - --k8s-api-burst=10
        - --wpa-default-max-disruption=100%
        - --queue-services=sqs,beanstalkd
+       - -v=2
        resources:
          limits:
            cpu: 100m

--- a/cmd/workerpodautoscaler/main.go
+++ b/cmd/workerpodautoscaler/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"k8s.io/klog/v2"
 
 	"github.com/spf13/cobra"
@@ -15,21 +17,17 @@ var rootCmd = &cobra.Command{
 	Long:  "workerpodautoscaler scales the kubernetes deployments based on queue length",
 }
 
-func localFlags(flags *pflag.FlagSet) {
-}
-
 func init() {
+	klog.InitFlags(nil)
 	cobra.OnInitialize(func() {
 		cmdutil.CheckErr(cmdutil.InitConfig("workerpodautoscaler"))
 	})
 
-	flags := rootCmd.PersistentFlags()
-	localFlags(flags)
+	rootCmd.PersistentFlags()
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
 }
 
 func main() {
-	klog.InitFlags(nil)
-
 	versionCommand := (&versionCmd{}).new()
 	runCommand := (&runCmd{}).new()
 


### PR DESCRIPTION
Standard: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

Default: -v=2

This standard of verbosity will follow in the next PRs.