### PR TITLE
promlog only warnings and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ wpa_controller_loop_duration_seconds{workerpodautoscaler="example-wpa", namespac
 
 wpa_log_messages_total{severity="ERROR"} 0
 wpa_log_messages_total{severity="WARNING"} 0
-wpa_log_messages_total{severity="INFO"} 0
 
 go_goroutines{endpoint="workerpodautoscaler-metrics"} 40
 ```

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -113,7 +113,7 @@ func (v *runCmd) run(cmd *cobra.Command, args []string) {
 	k8sApiQPS := float32(v.Viper.GetFloat64("k8s-api-qps"))
 	k8sApiBurst := v.Viper.GetInt("k8s-api-burst")
 
-	hook := promlog.MustNewPrometheusHook("wpa_")
+	hook := promlog.MustNewPrometheusHook("wpa_", klog.WarningSeverityLevel)
 	klog.AddHook(hook)
 
 	// // set up signals so we handle the first shutdown signal gracefully

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/practo/klog/v2 v2.2.1
-	github.com/practo/promlog v1.0.0-beta.2
+	github.com/practo/promlog v1.0.0
 	github.com/prometheus/client_golang v1.7.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/practo/klog/v2 v2.2.1 h1:yV/SavG73KHSmCVwtDap1RGe+2jd86e1eugT+Mv2/FA=
 github.com/practo/klog/v2 v2.2.1/go.mod h1:WMkpfPwTxLgSLookpI4UUv2zL7tMltKACK/FHB1zLV0=
-github.com/practo/promlog v1.0.0-beta.2 h1:ZNmzsVpIkPcubdUudtCn6J9Q16MU0HxSk1VB8DgktzQ=
-github.com/practo/promlog v1.0.0-beta.2/go.mod h1:gNtTwdRfC4UHAqBDWZ8xrSSFtACV689gWvpgGobYHXM=
+github.com/practo/promlog v1.0.0 h1:rPvp79Sa2IE6c0WqKtJanOXWLXdD4lyxCnl22CsohEI=
+github.com/practo/promlog v1.0.0/go.mod h1:gNtTwdRfC4UHAqBDWZ8xrSSFtACV689gWvpgGobYHXM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=

--- a/vendor/github.com/practo/promlog/.travis.yml
+++ b/vendor/github.com/practo/promlog/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+ - 1.14.x
+
+script:
+ - go test

--- a/vendor/github.com/practo/promlog/README.md
+++ b/vendor/github.com/practo/promlog/README.md
@@ -1,4 +1,8 @@
 # promlog
+
+[![GoDoc Widget]][GoDoc]
+
+---
 [forked klog](https://github.com/practo/klog) hook to expose the number of log messages as Prometheus metrics:
 ```
 log_messages_total{severity="ERROR"} 0
@@ -23,7 +27,7 @@ import (
 
 func main() {
 	// Create the Prometheus hook:
-	hook := promlog.MustNewPrometheusHook("")
+	hook := promlog.MustNewPrometheusHook("", klog.InfoSeverityLevel)
 
 	// Configure klog to use the Prometheus hook:
 	klog.AddHook(hook)
@@ -75,3 +79,6 @@ E0624 13:27:29.698964   51237 promlog_test.go:61] this is at error level!
 PASS
 ok  	github.com/practo/promlog	0.237s
 ```
+
+[GoDoc]: https://godoc.org/github.com/practo/promlog
+[GoDoc Widget]: https://godoc.org/github.com/practo/k8s-worker-pod-autoscaler?status.svg

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,7 +118,7 @@ github.com/pelletier/go-toml
 # github.com/practo/klog/v2 v2.2.1
 ## explicit
 github.com/practo/klog/v2
-# github.com/practo/promlog v1.0.0-beta.2
+# github.com/practo/promlog v1.0.0
 ## explicit
 github.com/practo/promlog
 # github.com/prometheus/client_golang v1.7.0


### PR DESCRIPTION
promlog only warnings and errors

use https://github.com/practo/promlog/releases/tag/v1.0.0 