### PR TITLE
automatically publish v1.0.0-beta tag when publishing suffixed tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ BASEIMAGE ?= gcr.io/distroless/static
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)
-BETA := v1.0.0-beta
+BETA := v1.0-beta
 
-ifneq (,$(findstring $(BETA),$(TAG)))
+ifneq (,$(findstring v1.0,$(TAG))$(findstring -beta,$(TAG)))
     PUBLISH_TAGS := $(IMAGE):$(TAG) $(IMAGE):$(BETA)
 else
     PUBLISH_TAGS := $(IMAGE):$(TAG)


### PR DESCRIPTION
I believe this should fix #82. Once out of beta the functionality will revert to the prior behavior, but the `PUBLISH_TAGS` logic could easily be changed to align with a `v1.0.x` track instead.

Output of `make -n push` post-change:

```
mkdir -p bin/darwin_amd64
mkdir -p .go/bin/darwin_amd64
mkdir -p .go/cache
echo "making bin/darwin_amd64/workerpodautoscaler"
docker run                                                 \
	    -i                                                      \
	    --rm                                                    \
	    -u $(id -u):$(id -g)                                  \
	    -v $(pwd):/src                                         \
	    -w /src                                                 \
	    -v $(pwd)/.go/bin/darwin_amd64:/go/bin                \
	    -v $(pwd)/.go/bin/darwin_amd64:/go/bin/darwin_amd64  \
	    -v $(pwd)/.go/cache:/.cache                            \
	    --env HTTP_PROXY=                          \
	    --env HTTPS_PROXY=                        \
	    golang:1.14.2-alpine                                          \
	    /bin/sh -c "                                            \
	        ARCH=amd64                                        \
	        OS=darwin                                            \
	        VERSION=v1.0.0-beta-59-gb1d9b7f-dirty                                  \
	        ./hack/build.sh                                    \
	    "
if ! cmp -s .go/bin/darwin_amd64/workerpodautoscaler bin/darwin_amd64/workerpodautoscaler; then \
	    mv .go/bin/darwin_amd64/workerpodautoscaler bin/darwin_amd64/workerpodautoscaler;            \
	    date >.go/bin/darwin_amd64/workerpodautoscaler.stamp;                              \
	fi
true
sed                                 \
	    -e 's|{ARG_BIN}|workerpodautoscaler|g'        \
	    -e 's|{ARG_ARCH}|amd64|g'      \
	    -e 's|{ARG_OS}|darwin|g'          \
	    -e 's|{ARG_FROM}|gcr.io/distroless/static|g' \
	    Dockerfile.in > .dockerfile-darwin_amd64
docker build  -t practodev/workerpodautoscaler:v1.0.0-beta-59-gb1d9b7f-dirty  -t practodev/workerpodautoscaler:v1.0.0-beta -f .dockerfile-darwin_amd64 .
docker images -q practodev/workerpodautoscaler:v1.0.0-beta-59-gb1d9b7f-dirty > .container-practodev_workerpodautoscaler-v1.0.0-beta-59-gb1d9b7f-dirty
docker push practodev/workerpodautoscaler:v1.0.0-beta-59-gb1d9b7f-dirty
docker push practodev/workerpodautoscaler:v1.0.0-beta
echo "pushed: practodev/workerpodautoscaler:v1.0.0-beta-59-gb1d9b7f-dirty"
echo "pushed: practodev/workerpodautoscaler:v1.0.0-beta"
```