### PR TITLE
Attempt partial scale down when maxDisruption is set and unprocessed jobs < target

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -496,7 +496,7 @@ func (c *Controller) getDesiredWorkers(
 		queueName, currentWorkers, idleWorkers)
 	klog.V(3).Infof("%s minComputed=%v, maxDisruptable=%v\n",
 		queueName, minWorkers, maxDisruptableWorkers)
-	klog.V(3).Infof("%s usageRatio=%v \n", usageRatio)
+	klog.V(3).Infof("%s usageRatio=%v \n", queueName, usageRatio)
 
 	if currentWorkers == 0 {
 		desiredWorkers := int32(math.Ceil(usageRatio))
@@ -511,7 +511,9 @@ func (c *Controller) getDesiredWorkers(
 
 	if queueMessages > 0 {
 		// return the current replicas if the change would be too small
-		if (math.Abs(1.0-usageRatio) <= tolerance) || (queueMessages < targetMessagesPerWorker) {
+		if (math.Abs(1.0-usageRatio) <= tolerance) ||
+			(queueMessages < targetMessagesPerWorker &&
+				maxDisruptableWorkers != 0) {
 			// desired is same as current in this scenario
 			return convertDesiredReplicasWithRules(
 				currentWorkers,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -341,7 +341,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		return nil
 	}
 
-	desiredWorkers := c.getDesiredWorkers(
+	desiredWorkers := GetDesiredWorkers(
 		queueName,
 		queueMessages,
 		messagesSentPerMinute,
@@ -353,7 +353,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		*workerPodAutoScaler.Spec.MaxReplicas,
 		workerPodAutoScaler.GetMaxDisruption(c.defaultMaxDisruption),
 	)
-	klog.V(1).Infof("%s: qMsgs: %d, desired: %d",
+	klog.V(1).Infof("%s qMsgs: %d, desired: %d",
 		queueName, queueMessages, desiredWorkers)
 
 	if desiredWorkers != *deployment.Spec.Replicas {
@@ -454,8 +454,8 @@ func getMinWorkers(
 	return minWorkers
 }
 
-// getDesiredWorkers finds the desired number of workers which are required
-func (c *Controller) getDesiredWorkers(
+// GetDesiredWorkers finds the desired number of workers which are required
+func GetDesiredWorkers(
 	queueName string,
 	queueMessages int32,
 	messagesSentPerMinute float64,
@@ -513,7 +513,7 @@ func (c *Controller) getDesiredWorkers(
 		// return the current replicas if the change would be too small
 		if (math.Abs(1.0-usageRatio) <= tolerance) ||
 			(queueMessages < targetMessagesPerWorker &&
-				maxDisruptableWorkers != 0) {
+				maxDisruptableWorkers == 0) {
 			// desired is same as current in this scenario
 			return convertDesiredReplicasWithRules(
 				currentWorkers,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -511,9 +511,7 @@ func GetDesiredWorkers(
 
 	if queueMessages > 0 {
 		// return the current replicas if the change would be too small
-		if (math.Abs(1.0-usageRatio) <= tolerance) ||
-			(queueMessages < targetMessagesPerWorker &&
-				maxDisruptableWorkers == 0) {
+		if math.Abs(1.0-usageRatio) <= tolerance {
 			// desired is same as current in this scenario
 			return convertDesiredReplicasWithRules(
 				currentWorkers,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,41 @@
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
+)
+
+// TestScaleDownWhenQueueMessagesLessThanTarget tests scale down
+//  when unprocessed messages is less than targetMessagesPerWorker #89
+func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
+	queueName := "otpsms"
+	queueMessages := int32(10)
+	messagesSentPerMinute := float64(10)
+	secondsToProcessOneJob := float64(0.3)
+	targetMessagesPerWorker := int32(200)
+	currentWorkers := int32(20)
+	idleWorkers := int32(0)
+	minWorkers := int32(0)
+	maxWorkers := int32(20)
+	maxDisruption := "10%"
+	expectedDesired := int32(18)
+
+	desiredWorkers := controller.GetDesiredWorkers(
+		queueName,
+		queueMessages,
+		messagesSentPerMinute,
+		secondsToProcessOneJob,
+		targetMessagesPerWorker,
+		currentWorkers,
+		idleWorkers,
+		minWorkers,
+		maxWorkers,
+		&maxDisruption,
+	)
+
+	if desiredWorkers != expectedDesired {
+		t.Errorf("expected-desired=%v, got-desired=%v\n", desiredWorkers,
+			expectedDesired)
+	}
+}


### PR DESCRIPTION
Fixes #89 

Also, adds verbosity level for few important calls.

Result after this PR was made live at 20:32:
<img width="1277" alt="Screenshot 2020-07-03 at 8 47 32 PM" src="https://user-images.githubusercontent.com/9006763/86481881-78440f80-bd6e-11ea-989d-b3812b6de890.png">

