### PR TITLE
Scale up should consider readiness delay if specified

### DIFF
--- a/pkg/apis/workerpodautoscaler/v1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1/types.go
@@ -30,9 +30,11 @@ type WorkerPodAutoScalerSpec struct {
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource
 type WorkerPodAutoScalerStatus struct {
-	CurrentMessages int32 `json:"CurrentMessages"`
-	CurrentReplicas int32 `json:"CurrentReplicas"`
-	DesiredReplicas int32 `json:"DesiredReplicas"`
+	CurrentMessages   int32        `json:"CurrentMessages"`
+	CurrentReplicas   int32        `json:"CurrentReplicas"`
+	DesiredReplicas   int32        `json:"DesiredReplicas"`
+	LastScaleUpTime   *metav1.Time `json:"LastScaleUpTime"`
+	LastScaleDownTime *metav1.Time `json:"LastScaleDownTime"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/workerpodautoscaler/v1alpha1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1alpha1/types.go
@@ -30,9 +30,11 @@ type WorkerPodAutoScalerSpec struct {
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource
 type WorkerPodAutoScalerStatus struct {
-	CurrentMessages int32 `json:"CurrentMessages"`
-	CurrentReplicas int32 `json:"CurrentReplicas"`
-	DesiredReplicas int32 `json:"DesiredReplicas"`
+	CurrentMessages   int32        `json:"CurrentMessages"`
+	CurrentReplicas   int32        `json:"CurrentReplicas"`
+	DesiredReplicas   int32        `json:"DesiredReplicas"`
+	LastScaleUpTime   *metav1.Time `json:"LastScaleUpTime"`
+	LastScaleDownTime *metav1.Time `json:"LastScaleDownTime"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2,14 +2,16 @@ package controller_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestScaleDownWhenQueueMessagesLessThanTarget tests scale down
 //  when unprocessed messages is less than targetMessagesPerWorker #89
 func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
-	queueName := "otpsms"
+	queueName := "q"
 	queueMessages := int32(10)
 	messagesSentPerMinute := float64(10)
 	secondsToProcessOneJob := float64(0.3)
@@ -19,6 +21,7 @@ func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
 	minWorkers := int32(0)
 	maxWorkers := int32(20)
 	maxDisruption := "10%"
+	readinessDelaySeconds := int32(0)
 	expectedDesired := int32(18)
 
 	desiredWorkers := controller.GetDesiredWorkers(
@@ -32,6 +35,8 @@ func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
 		minWorkers,
 		maxWorkers,
 		&maxDisruption,
+		readinessDelaySeconds,
+		nil,
 	)
 
 	if desiredWorkers != expectedDesired {
@@ -43,7 +48,7 @@ func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
 // TestScaleUpWhenCalculatedMinIsGreaterThanMax
 // when calculated min is greater than max
 func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
-	queueName := "otpsms"
+	queueName := "q"
 	queueMessages := int32(1)
 	messagesSentPerMinute := float64(2136.6)
 	secondsToProcessOneJob := float64(10)
@@ -53,6 +58,7 @@ func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
 	minWorkers := int32(2)
 	maxWorkers := int32(20)
 	maxDisruption := "0%"
+	readinessDelaySeconds := int32(0)
 	expectedDesired := int32(20)
 
 	desiredWorkers := controller.GetDesiredWorkers(
@@ -66,6 +72,88 @@ func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
 		minWorkers,
 		maxWorkers,
 		&maxDisruption,
+		readinessDelaySeconds,
+		nil,
+	)
+
+	if desiredWorkers != expectedDesired {
+		t.Errorf("expected-desired=%v, got-desired=%v\n", expectedDesired,
+			desiredWorkers)
+	}
+}
+
+// TestScaleUpPreventionWhenReadinessDelayHasNotExpired
+// scale up should be prevented if readiness delay has not expired
+func TestScaleUpPreventionWhenReadinessDelayHasNotExpired(t *testing.T) {
+	queueName := "q"
+	queueMessages := int32(1)
+	messagesSentPerMinute := float64(2136)
+	secondsToProcessOneJob := float64(10)
+	targetMessagesPerWorker := int32(2500)
+	currentWorkers := int32(10)
+	idleWorkers := int32(0)
+	minWorkers := int32(2)
+	maxWorkers := int32(20)
+	maxDisruption := "0%"
+	readinessDelaySeconds := int32(600)
+	lastScaleUpTime := &metav1.Time{
+		Time: time.Now().Add(time.Second * time.Duration(-300)),
+	}
+	expectedDesired := int32(10)
+
+	desiredWorkers := controller.GetDesiredWorkers(
+		queueName,
+		queueMessages,
+		messagesSentPerMinute,
+		secondsToProcessOneJob,
+		targetMessagesPerWorker,
+		currentWorkers,
+		idleWorkers,
+		minWorkers,
+		maxWorkers,
+		&maxDisruption,
+		readinessDelaySeconds,
+		lastScaleUpTime,
+	)
+
+	if desiredWorkers != expectedDesired {
+		t.Errorf("expected-desired=%v, got-desired=%v\n", expectedDesired,
+			desiredWorkers)
+	}
+}
+
+// TestScaleUpWhenReadinessDelayHasExpired
+// scale up should be prevented if readiness delay has expired
+func TestScaleUpWhenReadinessDelayHasExpired(t *testing.T) {
+	queueName := "q"
+	queueMessages := int32(1)
+	messagesSentPerMinute := float64(2136)
+	secondsToProcessOneJob := float64(10)
+	targetMessagesPerWorker := int32(2500)
+	currentWorkers := int32(10)
+	idleWorkers := int32(0)
+	minWorkers := int32(2)
+	maxWorkers := int32(20)
+	maxDisruption := "0%"
+	readinessDelaySeconds := int32(250)
+	lastScaleUpTime := &metav1.Time{
+		Time: time.Now().Add(time.Second * time.Duration(-300)),
+	}
+	expectedDesired := int32(20)
+
+	desiredWorkers := controller.GetDesiredWorkers(
+		queueName,
+		queueMessages,
+		messagesSentPerMinute,
+		secondsToProcessOneJob,
+		targetMessagesPerWorker,
+		currentWorkers,
+		idleWorkers,
+		minWorkers,
+		maxWorkers,
+		&maxDisruption,
+		readinessDelaySeconds,
+		lastScaleUpTime,
 	)
 
 	if desiredWorkers != expectedDesired {


### PR DESCRIPTION
Fixes #67

- Consider [initialDelaySeconds](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) when doing scale ups. If a Kubernetes Deployment or ReplicaSet has defined the initialDelayReadinessSeconds, then scale up will happen only when that number of seconds have passed from the last scale up time.
- Adds `LastScaleUpTime` and `LastScaleDownTime` in WPA status
