### PR TITLE
Fix desired logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ Beanstalk's queueURI would be like: `beanstalk://beanstalkDNSName:11300/test-tub
 
 - `targetMessagesPerWorker`:
 ```
-
+availableMessages=90(backlog), reservedMessages=110(inprocess), and 10 workers are required to process 110+90=200 messages then
+targetMessagesPerWorker=110+90/10 = 20
 ```
 
 - `secondsToProcessOneJob`:
 ```
-
+secondsToProcessOneJob=0.5
+queueRPM=300
+min=1
+minWorkersBasedOnRPM=Ceil(0.5*300/60)=3, so there will be minium 3 workers running based on the RPM.
 ```
 
 - `maxDisruption`:

--- a/README.md
+++ b/README.md
@@ -84,13 +84,25 @@ Beanstalk's queueURI would be like: `beanstalk://beanstalkDNSName:11300/test-tub
 | deploymentName | Name of the kubernetes Deployment in the same namespace as WPA object. | No* |
 | replicaSetName | Name of the kubernetes ReplicaSet in the same namespace as WPA object. | No* |
 | queueURI       | Full URL of the queue.                                                 | Yes |
-| targetMessagesPerWorker |  Number of jobs in the queue which have not been picked up by the workers. This is also used to calculate the desired number of workers. | Yes |
-| secondsToProcessOneJob | This metric is useful to calculate the desired number of workers more accurately. It is particularly very useful for workers which have `targetMessagesPerWorker` as always zero. `secondsToProcessOneJob` in the combination with `messagesSentPerMinute`(queue RPM) helps in calculating the minimum workers that is expected to be running to handle `messagesSentPerMinute`(RPM) with every job being processed in `secondsToProcessOneJob` seconds. (highly recommended, default=0.0 i.e. disabled). | No |
+| targetMessagesPerWorker | Target ratio between the number of jobs that are not fully processed and no of workers required to process them | Yes |
+| secondsToProcessOneJob | For fast running workers doing high RPM, the backlog is very close to zero. So for such workers scale up cannot happen based on the backlog, hence this is a really important specification to always keep the minimum number of workers running based on the queue RPM. (highly recommended, default=0.0 i.e. disabled). | No |
 | maxDisruption | Amount of disruption that can be tolerated in a single scale down activity. Number of pods or percentage of pods that can scale down in a single down scale down activity. Using this you can control how fast a scale down can happen. This can be expressed both as an absolute value and a percentage. (default is the WPA flag `--wpa-default-max-disruption`). | No |
 
-*It is mandatory to set either `deploymentName` or `replicaSetName`.
+* It is mandatory to set either `deploymentName` or `replicaSetName`.
 
-`maxDisruption` explained with the help of some examples:
+### Explained the above specifications with examples:
+
+- `targetMessagesPerWorker`:
+```
+
+```
+
+- `secondsToProcessOneJob`:
+```
+
+```
+
+- `maxDisruption`:
 ```
 min=2, max=1000, current=500, maxDisruption=50%: then the scale down cannot bring down more than 250 pods in a single scale down activity.
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Beanstalk's queueURI would be like: `beanstalk://beanstalkDNSName:11300/test-tub
 | deploymentName | Name of the kubernetes Deployment in the same namespace as WPA object. | No* |
 | replicaSetName | Name of the kubernetes ReplicaSet in the same namespace as WPA object. | No* |
 | queueURI       | Full URL of the queue.                                                 | Yes |
-| targetMessagesPerWorker | Target ratio between the number of jobs that are not fully processed and no of workers required to process them | Yes |
+| targetMessagesPerWorker | Target ratio between the number of queued jobs(both available and reserved) and the number of workers required to process them. For long running workers with visible backlog, this value may be set to 1 so that each job spawns a new worker (upto maxReplicas). | Yes |
 | secondsToProcessOneJob | For fast running workers doing high RPM, the backlog is very close to zero. So for such workers scale up cannot happen based on the backlog, hence this is a really important specification to always keep the minimum number of workers running based on the queue RPM. (highly recommended, default=0.0 i.e. disabled). | No |
 | maxDisruption | Amount of disruption that can be tolerated in a single scale down activity. Number of pods or percentage of pods that can scale down in a single down scale down activity. Using this you can control how fast a scale down can happen. This can be expressed both as an absolute value and a percentage. (default is the WPA flag `--wpa-default-max-disruption`). | No |
 

--- a/artifacts/crd.yaml
+++ b/artifacts/crd.yaml
@@ -69,12 +69,12 @@ spec:
               targetMessagesPerWorker:
                 type: integer
                 format: int32
-                description: 'Number of jobs in the queue which have not been picked up by the workers. This also used to calculate the desired number of workers'
+                description: 'Target ratio between the number of queued jobs(both available and reserved) and the number of workers required to process them. For long running workers with visible backlog, this value may be set to 1 so that each job spawns a new worker (upto maxReplicas)'
               secondsToProcessOneJob:
                 type: number
                 format: float
                 nullable: true
-                description: 'This metric is useful to calculate the desired number of workers more accurately. It is particularly very useful for workers which have `targetMessagesPerWorker` as always zero. `secondsToProcessOneJob` in the combination with `messagesSentPerMinute`(queue RPM) helps in calculating the minimum workers that is expected to be running to handle `messagesSentPerMinute`(RPM) with every job being processed in `secondsToProcessOneJob` seconds'
+                description: 'For fast running workers doing high RPM, the backlog is very close to zero. So for such workers scale up cannot happen based on the backlog, hence this is a really important specification to always keep the minimum number of workers running based on the queue RPM. (highly recommended, default=0.0 i.e. disabled).'
   - name: v1alpha1
     served: true
     storage: false

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -o errexit
 set -o nounset
 set -o pipefail
 

--- a/pkg/apis/workerpodautoscaler/v1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1/types.go
@@ -30,9 +30,10 @@ type WorkerPodAutoScalerSpec struct {
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource
 type WorkerPodAutoScalerStatus struct {
-	CurrentMessages int32 `json:"CurrentMessages"`
-	CurrentReplicas int32 `json:"CurrentReplicas"`
-	DesiredReplicas int32 `json:"DesiredReplicas"`
+	CurrentMessages   int32 `json:"CurrentMessages"`
+	CurrentReplicas   int32 `json:"CurrentReplicas"`
+	AvailableReplicas int32 `json:"AvailableReplicas"`
+	DesiredReplicas   int32 `json:"DesiredReplicas"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/workerpodautoscaler/v1alpha1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1alpha1/types.go
@@ -30,9 +30,10 @@ type WorkerPodAutoScalerSpec struct {
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource
 type WorkerPodAutoScalerStatus struct {
-	CurrentMessages int32 `json:"CurrentMessages"`
-	CurrentReplicas int32 `json:"CurrentReplicas"`
-	DesiredReplicas int32 `json:"DesiredReplicas"`
+	CurrentMessages   int32 `json:"CurrentMessages"`
+	CurrentReplicas   int32 `json:"CurrentReplicas"`
+	AvailableReplicas int32 `json:"AvailableReplicas"`
+	DesiredReplicas   int32 `json:"DesiredReplicas"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -126,6 +126,16 @@ var (
 		},
 		[]string{"workerpodautoscaler", "namespace", "queueName"},
 	)
+
+	workersAvailable = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "wpa",
+			Subsystem: "worker",
+			Name:      "available",
+			Help:      "Number of available workers",
+		},
+		[]string{"workerpodautoscaler", "namespace", "queueName"},
+	)
 )
 
 func init() {
@@ -136,6 +146,7 @@ func init() {
 	prometheus.MustRegister(workersIdle)
 	prometheus.MustRegister(workersCurrent)
 	prometheus.MustRegister(workersDesired)
+	prometheus.MustRegister(workersAvailable)
 }
 
 type WokerPodAutoScalerEvent struct {
@@ -340,7 +351,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		return err
 	}
 
-	var workers, availableWorkers int32
+	var currentWorkers, availableWorkers int32
 	deploymentName := workerPodAutoScaler.Spec.DeploymentName
 	replicaSetName := workerPodAutoScaler.Spec.ReplicaSetName
 	if deploymentName != "" {
@@ -352,7 +363,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		} else if err != nil {
 			return err
 		}
-		workers = *deployment.Spec.Replicas
+		currentWorkers = *deployment.Spec.Replicas
 		availableWorkers = deployment.Status.AvailableReplicas
 	} else if replicaSetName != "" {
 		// Get the ReplicaSet with the name specified in WorkerPodAutoScaler.spec
@@ -363,7 +374,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		} else if err != nil {
 			return err
 		}
-		workers = *replicaSet.Spec.Replicas
+		currentWorkers = *replicaSet.Spec.Replicas
 		availableWorkers = replicaSet.Status.AvailableReplicas
 	} else {
 		// We choose to absorb the error here as the worker would requeue the
@@ -384,7 +395,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 			namespace,
 			name,
 			workerPodAutoScaler.Spec.QueueURI,
-			workers,
+			currentWorkers,
 			secondsToProcessOneJob,
 		)
 	case WokerPodAutoScalerEventUpdate:
@@ -392,7 +403,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 			namespace,
 			name,
 			workerPodAutoScaler.Spec.QueueURI,
-			workers,
+			currentWorkers,
 			secondsToProcessOneJob,
 		)
 	case WokerPodAutoScalerEventDelete:
@@ -415,7 +426,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		messagesSentPerMinute,
 		secondsToProcessOneJob,
 		*workerPodAutoScaler.Spec.TargetMessagesPerWorker,
-		availableWorkers,
+		currentWorkers,
 		idleWorkers,
 		*workerPodAutoScaler.Spec.MinReplicas,
 		*workerPodAutoScaler.Spec.MaxReplicas,
@@ -444,14 +455,19 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		name,
 		namespace,
 		queueName,
-	).Set(float64(availableWorkers))
+	).Set(float64(currentWorkers))
 	workersDesired.WithLabelValues(
 		name,
 		namespace,
 		queueName,
 	).Set(float64(desiredWorkers))
+	workersAvailable.WithLabelValues(
+		name,
+		namespace,
+		queueName,
+	).Set(float64(availableWorkers))
 
-	if desiredWorkers != workers {
+	if desiredWorkers != currentWorkers {
 		if deploymentName != "" {
 			c.updateDeployment(workerPodAutoScaler.Namespace, deploymentName, &desiredWorkers)
 		} else {
@@ -467,6 +483,7 @@ func (c *Controller) syncHandler(event WokerPodAutoScalerEvent) error {
 		c.customclientset,
 		desiredWorkers,
 		workerPodAutoScaler,
+		currentWorkers,
 		availableWorkers,
 		queueMessages,
 	)
@@ -725,10 +742,12 @@ func updateWorkerPodAutoScalerStatus(
 	customclientset clientset.Interface,
 	desiredWorkers int32,
 	workerPodAutoScaler *v1alpha1.WorkerPodAutoScaler,
-	availableReplicas int32,
+	currentWorkers int32,
+	availableWorkers int32,
 	queueMessages int32) {
 
-	if workerPodAutoScaler.Status.CurrentReplicas == availableReplicas &&
+	if workerPodAutoScaler.Status.CurrentReplicas == currentWorkers &&
+		workerPodAutoScaler.Status.AvailableReplicas == availableWorkers &&
 		workerPodAutoScaler.Status.DesiredReplicas == desiredWorkers &&
 		workerPodAutoScaler.Status.CurrentMessages == queueMessages {
 		klog.Infof("%s/%s: WPA status is already up to date\n", namespace, name)
@@ -741,7 +760,8 @@ func updateWorkerPodAutoScalerStatus(
 	// You can use DeepCopy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance
 	workerPodAutoScalerCopy := workerPodAutoScaler.DeepCopy()
-	workerPodAutoScalerCopy.Status.CurrentReplicas = availableReplicas
+	workerPodAutoScalerCopy.Status.CurrentReplicas = currentWorkers
+	workerPodAutoScalerCopy.Status.AvailableReplicas = availableWorkers
 	workerPodAutoScalerCopy.Status.DesiredReplicas = desiredWorkers
 	workerPodAutoScalerCopy.Status.CurrentMessages = queueMessages
 	// If the CustomResourceSubresources feature gate is not enabled,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -642,7 +642,7 @@ func GetDesiredWorkers(
 	klog.V(4).Infof("%s qMsgs=%v, qMsgsPerMin=%v \n",
 		queueName, queueMessages, messagesSentPerMinute)
 	klog.V(4).Infof("%s secToProcessJob=%v, maxDisruption=%v \n",
-		queueName, secondsToProcessOneJob, maxDisruption)
+		queueName, secondsToProcessOneJob, *maxDisruption)
 	klog.V(4).Infof("%s current=%v, idle=%v \n",
 		queueName, currentWorkers, idleWorkers)
 	klog.V(3).Infof("%s minComputed=%v, maxDisruptable=%v\n",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -596,7 +596,7 @@ func getMinWorkers(
 }
 
 func isChangeTooSmall(desired int32, current int32, tolerance float64) bool {
-	if math.Abs(float64((desired-current)/current)) <= tolerance {
+	if math.Abs(float64(desired-current))/float64(current) <= tolerance {
 		return true
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -116,3 +116,45 @@ func TestScaleForLongRunningWorkersTakingMinutesToProcess(t *testing.T) {
 	c.maxDisruption = "100%"
 	c.test(t, 5)
 }
+
+// TestTargetScalingForLongRunningWorkers
+// The test cases show secondsToProcessOneJob becomes ineffective
+// and the need of having targetMessagesPerWorker
+// #97
+func TestTargetScalingForLongRunningWorkers(t *testing.T) {
+	c := desiredWorkerTester{
+		queueName:               "q",
+		queueMessages:           20,
+		messagesSentPerMinute:   float64(0),   // rpm averaged over 10mins
+		secondsToProcessOneJob:  float64(300), // lot of time to process
+		targetMessagesPerWorker: 10,
+		currentWorkers:          0,
+		idleWorkers:             0,
+		minWorkers:              0,
+		maxWorkers:              100,
+		maxDisruption:           "100%",
+	}
+
+	c.test(t, 2)
+}
+
+// TestRPMScalingForFastRunningWorkers
+// targetMessagesPerWorker becomes ineffective
+// and the need of having secondsToProcessOneJob
+// #97
+func TestRPMScalingForFastRunningWorkers(t *testing.T) {
+	c := desiredWorkerTester{
+		queueName:               "q",
+		queueMessages:           0,            // queued jobs=0, in process=0
+		messagesSentPerMinute:   float64(120), // rpm averaged over 10mins
+		secondsToProcessOneJob:  float64(1),   // fast processing
+		targetMessagesPerWorker: 60,
+		currentWorkers:          1,
+		idleWorkers:             0,
+		minWorkers:              0,
+		maxWorkers:              100,
+		maxDisruption:           "100%",
+	}
+
+	c.test(t, 2)
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,70 +6,75 @@ import (
 	"github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
 )
 
+type desiredWorkerTester struct {
+	queueName               string
+	queueMessages           int32
+	messagesSentPerMinute   float64
+	secondsToProcessOneJob  float64
+	targetMessagesPerWorker int32
+	currentWorkers          int32
+	idleWorkers             int32
+	minWorkers              int32
+	maxWorkers              int32
+	maxDisruption           string
+}
+
+func (c *desiredWorkerTester) getDesired() int32 {
+	return controller.GetDesiredWorkers(
+		c.queueName,
+		c.queueMessages,
+		c.messagesSentPerMinute,
+		c.secondsToProcessOneJob,
+		c.targetMessagesPerWorker,
+		c.currentWorkers,
+		c.idleWorkers,
+		c.minWorkers,
+		c.maxWorkers,
+		&c.maxDisruption,
+	)
+}
+
+func (c *desiredWorkerTester) test(t *testing.T, expected int32) {
+	desired := c.getDesired()
+	if desired != expected {
+		t.Errorf("desired=%v, expected=%v\n", desired, expected)
+	}
+}
+
 // TestScaleDownWhenQueueMessagesLessThanTarget tests scale down
 //  when unprocessed messages is less than targetMessagesPerWorker #89
 func TestScaleDownWhenQueueMessagesLessThanTarget(t *testing.T) {
-	queueName := "otpsms"
-	queueMessages := int32(10)
-	messagesSentPerMinute := float64(10)
-	secondsToProcessOneJob := float64(0.3)
-	targetMessagesPerWorker := int32(200)
-	currentWorkers := int32(20)
-	idleWorkers := int32(0)
-	minWorkers := int32(0)
-	maxWorkers := int32(20)
-	maxDisruption := "10%"
-	expectedDesired := int32(18)
-
-	desiredWorkers := controller.GetDesiredWorkers(
-		queueName,
-		queueMessages,
-		messagesSentPerMinute,
-		secondsToProcessOneJob,
-		targetMessagesPerWorker,
-		currentWorkers,
-		idleWorkers,
-		minWorkers,
-		maxWorkers,
-		&maxDisruption,
-	)
-
-	if desiredWorkers != expectedDesired {
-		t.Errorf("expected-desired=%v, got-desired=%v\n", expectedDesired,
-			desiredWorkers)
+	c := desiredWorkerTester{
+		queueName:               "q",
+		queueMessages:           10,
+		messagesSentPerMinute:   float64(10),
+		secondsToProcessOneJob:  float64(0.3),
+		targetMessagesPerWorker: 200,
+		currentWorkers:          20,
+		idleWorkers:             0,
+		minWorkers:              0,
+		maxWorkers:              20,
+		maxDisruption:           "10%",
 	}
+
+	c.test(t, 18)
 }
 
 // TestScaleUpWhenCalculatedMinIsGreaterThanMax
 // when calculated min is greater than max
 func TestScaleUpWhenCalculatedMinIsGreaterThanMax(t *testing.T) {
-	queueName := "otpsms"
-	queueMessages := int32(1)
-	messagesSentPerMinute := float64(2136.6)
-	secondsToProcessOneJob := float64(10)
-	targetMessagesPerWorker := int32(2500)
-	currentWorkers := int32(10)
-	idleWorkers := int32(0)
-	minWorkers := int32(2)
-	maxWorkers := int32(20)
-	maxDisruption := "0%"
-	expectedDesired := int32(20)
-
-	desiredWorkers := controller.GetDesiredWorkers(
-		queueName,
-		queueMessages,
-		messagesSentPerMinute,
-		secondsToProcessOneJob,
-		targetMessagesPerWorker,
-		currentWorkers,
-		idleWorkers,
-		minWorkers,
-		maxWorkers,
-		&maxDisruption,
-	)
-
-	if desiredWorkers != expectedDesired {
-		t.Errorf("expected-desired=%v, got-desired=%v\n", expectedDesired,
-			desiredWorkers)
+	c := desiredWorkerTester{
+		queueName:               "q",
+		queueMessages:           1,
+		messagesSentPerMinute:   float64(2136),
+		secondsToProcessOneJob:  float64(10),
+		targetMessagesPerWorker: 2500,
+		currentWorkers:          10,
+		idleWorkers:             0,
+		minWorkers:              2,
+		maxWorkers:              20,
+		maxDisruption:           "0%",
 	}
+
+	c.test(t, 20)
 }


### PR DESCRIPTION
Fixes #101 #67 
- Fix the desired calculation bug, also add test case to validate it.
- Use spec replicas instead of available replicas. MoreInfo: https://github.com/practo/k8s-worker-pod-autoscaler/pull/105/commits/f00ef3fc03b84337573a1047c65bc81a3dbe0866
- Refactor desired calculation test cases to reduce redudancy. `desiredWorkerTester {}`
- Update description of `targetMessagesPerWorker` with note about long running workers MoreInfo: https://github.com/practo/k8s-worker-pod-autoscaler/pull/105/commits/19f2cbfab5845d7edce229e26dd841f34f2e18fc
- Test cases for RPM and target scaling for fast and long running workers resp.