### PR TITLE
Add omitempty tag to optional spec types

### DIFF
--- a/pkg/apis/workerpodautoscaler/v1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1/types.go
@@ -20,12 +20,12 @@ type WorkerPodAutoScaler struct {
 type WorkerPodAutoScalerSpec struct {
 	MinReplicas             *int32   `json:"minReplicas"`
 	MaxReplicas             *int32   `json:"maxReplicas"`
-	MaxDisruption           *string  `json:"maxDisruption"`
+	MaxDisruption           *string  `json:"maxDisruption,omitempty"`
 	QueueURI                string   `json:"queueURI"`
-	DeploymentName          string   `json:"deploymentName"`
-	ReplicaSetName          string   `json:"replicaSetName"`
+	DeploymentName          string   `json:"deploymentName,omitempty"`
+	ReplicaSetName          string   `json:"replicaSetName,omitempty"`
 	TargetMessagesPerWorker *int32   `json:"targetMessagesPerWorker"`
-	SecondsToProcessOneJob  *float64 `json:"secondsToProcessOneJob"`
+	SecondsToProcessOneJob  *float64 `json:"secondsToProcessOneJob,omitempty"`
 }
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource

--- a/pkg/apis/workerpodautoscaler/v1alpha1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1alpha1/types.go
@@ -20,12 +20,12 @@ type WorkerPodAutoScaler struct {
 type WorkerPodAutoScalerSpec struct {
 	MinReplicas             *int32   `json:"minReplicas"`
 	MaxReplicas             *int32   `json:"maxReplicas"`
-	MaxDisruption           *string  `json:"maxDisruption"`
+	MaxDisruption           *string  `json:"maxDisruption,omitempty"`
 	QueueURI                string   `json:"queueURI"`
-	DeploymentName          string   `json:"deploymentName"`
-	ReplicaSetName          string   `json:"replicaSetName"`
+	DeploymentName          string   `json:"deploymentName,omitempty"`
+	ReplicaSetName          string   `json:"replicaSetName,omitempty"`
 	TargetMessagesPerWorker *int32   `json:"targetMessagesPerWorker"`
-	SecondsToProcessOneJob  *float64 `json:"secondsToProcessOneJob"`
+	SecondsToProcessOneJob  *float64 `json:"secondsToProcessOneJob,omitempty"`
 }
 
 // WorkerPodAutoScalerStatus is the status for a WorkerPodAutoScaler resource


### PR DESCRIPTION
👋 I'm adding these `omitempty` tags in the WPA spec after running into an [automation](https://github.com/Medium/picchu/pull/276) issue. A WPA resource generated from the existing `WorkerPodAutoScaler` spec is not valid or accepted by the CRD, since both `DeploymentName` and `ReplicaSetName` are always included, even when not specified. Generated WPA resources end up triggering a violation the [oneOf validation](https://github.com/practo/k8s-worker-pod-autoscaler/blob/master/artifacts/crd.yaml#L42), and cannot be applied. The PR omits empty `DeploymentName` and `ReplicaSetName` fields, along with the optional fields in the WPA spec.