### PR TITLE
Use sync map for storing caches in sqs

### DIFF
--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -168,7 +168,6 @@ func (v *runCmd) run(cmd *cobra.Command, args []string) {
 	}
 
 	for _, queuingService := range queuingServices {
-		go queuingService.Sync(stopCh)
 		poller := queue.NewPoller(queues, queuingService)
 		go poller.Sync(stopCh)
 		go poller.Run(stopCh)

--- a/pkg/queue/beanstalk.go
+++ b/pkg/queue/beanstalk.go
@@ -307,13 +307,6 @@ func (b *Beanstalk) GetName() string {
 	return b.name
 }
 
-func (b *Beanstalk) Sync(stopCh <-chan struct{}) {
-	// Sync is only required when cache is implemented
-	// keeping the noop function to keep the impl same as
-	// other queue providers
-	return
-}
-
 func (b *Beanstalk) poll(key string, queueSpec QueueSpec) {
 	if queueSpec.workers == 0 && queueSpec.messages == 0 {
 		// If there are no workers running we do a long poll to find a job(s)

--- a/pkg/queue/beanstalk_test.go
+++ b/pkg/queue/beanstalk_test.go
@@ -54,7 +54,6 @@ func buildQueues(
 	if err != nil {
 		return nil, nil, err
 	}
-	go poller.Sync(stopCh)
 
 	return queues, poller.(*Beanstalk), nil
 }

--- a/pkg/queue/queue_service.go
+++ b/pkg/queue/queue_service.go
@@ -15,7 +15,6 @@ const (
 type QueuingService interface {
 	// GetName returns the name of the queing service
 	GetName() string
-	Sync(stopCh <-chan struct{})
 	// poll functions polls the queue service provider is responsible to update
 	// the queueSpec with the polled information
 	// informations it updates are


### PR DESCRIPTION
Fixes #110 

Reason: https://github.com/practo/k8s-worker-pod-autoscaler/blob/72674051af0fd96ca74c92c2c22f72a52f29f17d/pkg/queue/sqs.go#L277 allCache is a map paralley being written from another thread. Maps are referrence to same data, so a returned value is also the same data being worked on, to avoid such issues it is better to use std libray's [sync map](https://golang.org/pkg/sync/#Map).