### PR TITLE
Upgraded to Go1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ define \n
 
 endef
 
-BUILD_IMAGE ?= golang:1.14.2-alpine
-TEST_IMAGE ?= practodev/golang:1.14.2-alpine-test
+BUILD_IMAGE ?= golang:1.15.0-alpine
+TEST_IMAGE ?= practodev/golang:1.15.0-alpine-test
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.

--- a/artifacts/golang/1.15.0-alpine-test/Dockerfile
+++ b/artifacts/golang/1.15.0-alpine-test/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.15.0-alpine
+
+RUN apk add beanstalkd

--- a/artifacts/golang/README.md
+++ b/artifacts/golang/README.md
@@ -2,13 +2,13 @@
 
 Test image used for `make test`.
 
-Current image being used: `practodev/golang:1.14.2-alpine-test`
+Current image being used: `practodev/golang:1.15.0-alpine-test`
 
 ### Why?
 It keeps all the test dependencies installed on top of golang package
 
 ### Built using
 ```
-cd 1.14.2-alpine-test
-docker build -t practodev/golang:1.14.2-alpine-test .
+cd 1.15.0-alpine-test
+docker build -t practodev/golang:1.15.0-alpine-test .
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/practo/k8s-worker-pod-autoscaler
 
-go 1.14
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.34.3


### PR DESCRIPTION
https://golang.org/doc/go1.15
https://github.com/golang/go/wiki/Go-Release-Cycle

Binary size reduced by 3MB