### PR TITLE
Fix the unsupported 1.18 field

### DIFF
--- a/artifacts/crd.yaml
+++ b/artifacts/crd.yaml
@@ -14,7 +14,6 @@ spec:
     - wpa
     - wpas
     singular: workerpodautoscaler
-  preserveUnknownFields: true
   scope: Namespaced
   versions:
   - name: v1


### PR DESCRIPTION
Fixes
```
$ kubectl create -f artifacts/crd.yaml

The CustomResourceDefinition "workerpodautoscalers.k8s.practo.dev" is invalid: spec.preserveUnknownFields: Invalid value: true: cannot set to true, set x-preserve-unknown-fields to true in spec.versions[*].schema instead
```