### PR TITLE
Fixes unwanted scale down after wpa pod restarts

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -428,7 +428,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 
 	if queueMessages == queue.UnsyncedQueueMessageCount {
 		klog.Warningf(
-			"%s qMsgs: %d not uninitialized, waiting for init to complete",
+			"%s qMsgs: %d, q not initialized, waiting for init to complete",
 			queueName,
 			queueMessages,
 		)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -426,6 +426,15 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		return nil
 	}
 
+	if queueMessages == queue.UnsyncedQueueMessageCount {
+		klog.Warningf(
+			"%s qMsgs: %d not uninitialized, waiting for init to complete",
+			queueName,
+			queueMessages,
+		)
+		return nil
+	}
+
 	desiredWorkers := GetDesiredWorkers(
 		queueName,
 		queueMessages,


### PR DESCRIPTION
When worker pod autoscaler pod restarts, the message values are waiting to be initialized. At this time if the control loop for a queue runs, it scales down the deployment for it to zero as the controller works on the uninitialized value -1.

We should not work on uninitialized data.

Fixes #136 