### PR TITLE
Cooldown after last scale activity: scale-down-delay-after-last-scale-activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ min=2, max=1000, current=500, maxDisruption=125: then the scale down cannot brin
 ## WPA Controller
 
 ```
-$ bin/darwin_amd64/workerpodautoscaler run --help
 Run the workerpodautoscaler
 
 Usage:
@@ -127,21 +126,22 @@ Examples:
   workerpodautoscaler run
 
 Flags:
-      --aws-regions string                  comma separated aws regions of SQS (default "ap-south-1,ap-southeast-1")
-      --beanstalk-long-poll-interval int    the duration (in seconds) for which the beanstalk receive message call waits for a message to arrive (default 20)
-      --beanstalk-short-poll-interval int   the duration (in seconds) after which the next beanstalk api call is made to fetch the queue length (default 20)
-  -h, --help                                help for run
-      --k8s-api-burst int                   maximum burst for throttle between requests from clients(wpa) to k8s api (default 10)
-      --k8s-api-qps float                   qps indicates the maximum QPS to the k8s api from the clients(wpa). (default 5)
-      --kube-config string                  path of the kube config file, if not specified in cluster config is used
-      --metrics-port string                 specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA (default ":8787")
-      --namespace                           specify the namespace to listen to (default "" all namespaces)
-      --queue-services string               comma separated queue services, the WPA will start with (default "sqs,beanstalkd")
-      --resync-period int                   sync period for the worker pod autoscaler (default 20)
-      --sqs-long-poll-interval int          the duration (in seconds) for which the sqs receive message call waits for a message to arrive (default 20)
-      --sqs-short-poll-interval int         the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
-      --wpa-default-max-disruption string   it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
-      --wpa-threads int                     wpa threadiness, number of threads to process wpa resources (default 10)
+      --aws-regions string                    comma separated aws regions of SQS (default "ap-south-1,ap-southeast-1")
+      --beanstalk-long-poll-interval int      the duration (in seconds) for which the beanstalk receive message call waits for a message to arrive (default 20)
+      --beanstalk-short-poll-interval int     the duration (in seconds) after which the next beanstalk api call is made to fetch the queue length (default 20)
+  -h, --help                                  help for run
+      --k8s-api-burst int                     maximum burst for throttle between requests from clients(wpa) to k8s api (default 10)
+      --k8s-api-qps float                     qps indicates the maximum QPS to the k8s api from the clients(wpa). (default 5)
+      --kube-config string                    path of the kube config file, if not specified in cluster config is used
+      --metrics-port string                   specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA (default ":8787")
+      --namespace string                      specify the namespace to listen to
+      --queue-services string                 comma separated queue services, the WPA will start with (default "sqs,beanstalkd")
+      --resync-period int                     sync period for the worker pod autoscaler (default 20)
+      --scale-down-delay-after-scale-up int   scale down delay after last scale up in seconds (default 600)
+      --sqs-long-poll-interval int            the duration (in seconds) for which the sqs receive message call waits for a message to arrive (default 20)
+      --sqs-short-poll-interval int           the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
+      --wpa-default-max-disruption string     it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
+      --wpa-threads int                       wpa threadiness, number of threads to process wpa resources (default 10)
 
 Global Flags:
   -v, --v Level   number for the log level verbosity

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ min=2, max=1000, current=500, maxDisruption=125: then the scale down cannot brin
 ## WPA Controller
 
 ```
-$ bin/darwin_amd64/workerpodautoscaler run --help
 Run the workerpodautoscaler
 
 Usage:
@@ -127,22 +126,22 @@ Examples:
   workerpodautoscaler run
 
 Flags:
-      --aws-regions string                    comma separated aws regions of SQS (default "ap-south-1,ap-southeast-1")
-      --beanstalk-long-poll-interval int      the duration (in seconds) for which the beanstalk receive message call waits for a message to arrive (default 20)
-      --beanstalk-short-poll-interval int     the duration (in seconds) after which the next beanstalk api call is made to fetch the queue length (default 20)
-  -h, --help                                  help for run
-      --k8s-api-burst int                     maximum burst for throttle between requests from clients(wpa) to k8s api (default 10)
-      --k8s-api-qps float                     qps indicates the maximum QPS to the k8s api from the clients(wpa). (default 5)
-      --kube-config string                    path of the kube config file, if not specified in cluster config is used
-      --metrics-port string                   specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA (default ":8787")
-      --namespace string                      specify the namespace to listen to
-      --queue-services string                 comma separated queue services, the WPA will start with (default "sqs,beanstalkd")
-      --resync-period int                     sync period for the worker pod autoscaler (default 20)
-      --scale-down-delay-after-scale-up int   scale down delay after last scale up in seconds (default 600)
-      --sqs-long-poll-interval int            the duration (in seconds) for which the sqs receive message call waits for a message to arrive (default 20)
-      --sqs-short-poll-interval int           the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
-      --wpa-default-max-disruption string     it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
-      --wpa-threads int                       wpa threadiness, number of threads to process wpa resources (default 10)
+      --aws-regions string                               comma separated aws regions of SQS (default "ap-south-1,ap-southeast-1")
+      --beanstalk-long-poll-interval int                 the duration (in seconds) for which the beanstalk receive message call waits for a message to arrive (default 20)
+      --beanstalk-short-poll-interval int                the duration (in seconds) after which the next beanstalk api call is made to fetch the queue length (default 20)
+  -h, --help                                             help for run
+      --k8s-api-burst int                                maximum burst for throttle between requests from clients(wpa) to k8s api (default 10)
+      --k8s-api-qps float                                qps indicates the maximum QPS to the k8s api from the clients(wpa). (default 5)
+      --kube-config string                               path of the kube config file, if not specified in cluster config is used
+      --metrics-port string                              specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA (default ":8787")
+      --namespace string                                 specify the namespace to listen to
+      --queue-services string                            comma separated queue services, the WPA will start with (default "sqs,beanstalkd")
+      --resync-period int                                sync period for the worker pod autoscaler (default 20)
+      --scale-down-delay-after-last-scale-activity int   scale down delay after last scale up or down in seconds (default 600)
+      --sqs-long-poll-interval int                       the duration (in seconds) for which the sqs receive message call waits for a message to arrive (default 20)
+      --sqs-short-poll-interval int                      the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)
+      --wpa-default-max-disruption string                it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage. (default "100%")
+      --wpa-threads int                                  wpa threadiness, number of threads to process wpa resources (default 10)
 
 Global Flags:
   -v, --v Level   number for the log level verbosity

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ min=2, max=1000, current=500, maxDisruption=125: then the scale down cannot brin
 ## WPA Controller
 
 ```
+$ bin/darwin_amd64/workerpodautoscaler run --help
 Run the workerpodautoscaler
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Flags:
       --metrics-port string                              specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA (default ":8787")
       --namespace string                                 specify the namespace to listen to
       --queue-services string                            comma separated queue services, the WPA will start with (default "sqs,beanstalkd")
-      --resync-period int                                sync period for the worker pod autoscaler (default 20)
+      --resync-period int                                maximum sync period for the control loop but the control loop can execute sooner if the wpa status object gets updated. (default 20)
       --scale-down-delay-after-last-scale-activity int   scale down delay after last scale up or down in seconds (default 600)
       --sqs-long-poll-interval int                       the duration (in seconds) for which the sqs receive message call waits for a message to arrive (default 20)
       --sqs-short-poll-interval int                      the duration (in seconds) after which the next sqs api call is made to fetch the queue length (default 20)

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -65,7 +65,7 @@ func (v *runCmd) new() *cobra.Command {
 	}
 
 	flags.Int("scale-down-delay-after-last-scale-activity", 600, "scale down delay after last scale up or down in seconds")
-	flags.Int("resync-period", 20, "sync period for the worker pod autoscaler")
+	flags.Int("resync-period", 20, "maximum sync period for the control loop but the control loop can execute sooner if the wpa status object gets updated.")
 	flags.Int("wpa-threads", 10, "wpa threadiness, number of threads to process wpa resources")
 	flags.String("wpa-default-max-disruption", "100%", "it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage.")
 	flags.String("aws-regions", "ap-south-1,ap-southeast-1", "comma separated aws regions of SQS")

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -192,6 +192,7 @@ func (v *runCmd) run(cmd *cobra.Command, args []string) {
 		kubeInformerFactory.Apps().V1().ReplicaSets(),
 		customInformerFactory.K8s().V1().WorkerPodAutoScalers(),
 		wpaDefaultMaxDisruption,
+                resyncPeriod,
 		queues,
 	)
 

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/practo/k8s-worker-pod-autoscaler/pkg/signals"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	workerpodautoscalercontroller "github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
 	clientset "github.com/practo/k8s-worker-pod-autoscaler/pkg/generated/clientset/versioned"
@@ -47,6 +48,7 @@ func (v *runCmd) new() *cobra.Command {
 	flags := v.Cmd.Flags()
 
 	flagNames := []string{
+		"scale-down-delay-after-scale-up",
 		"resync-period",
 		"wpa-threads",
 		"wpa-default-max-disruption",
@@ -63,6 +65,7 @@ func (v *runCmd) new() *cobra.Command {
 		"namespace",
 	}
 
+	flags.Int("scale-down-delay-after-scale-up", 600, "scale down delay after last scale up in seconds")
 	flags.Int("resync-period", 20, "sync period for the worker pod autoscaler")
 	flags.Int("wpa-threads", 10, "wpa threadiness, number of threads to process wpa resources")
 	flags.String("wpa-default-max-disruption", "100%", "it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage.")
@@ -73,7 +76,6 @@ func (v *runCmd) new() *cobra.Command {
 	flags.Int("beanstalk-short-poll-interval", 20, "the duration (in seconds) after which the next beanstalk api call is made to fetch the queue length")
 	flags.Int("beanstalk-long-poll-interval", 20, "the duration (in seconds) for which the beanstalk receive message call waits for a message to arrive")
 	flags.String("queue-services", "sqs,beanstalkd", "comma separated queue services, the WPA will start with")
-
 	flags.String("metrics-port", ":8787", "specify where to serve the /metrics and /status endpoint. /metrics serve the prometheus metrics for WPA")
 	flags.Float64("k8s-api-qps", 5.0, "qps indicates the maximum QPS to the k8s api from the clients(wpa).")
 	flags.Int("k8s-api-burst", 10, "maximum burst for throttle between requests from clients(wpa) to k8s api")
@@ -99,8 +101,12 @@ func parseRegions(regionNames string) []string {
 }
 
 func (v *runCmd) run(cmd *cobra.Command, args []string) {
+	scaleDownDelay := time.Second * time.Duration(
+		viper.GetInt("scale-down-delay-after-scale-up"),
+	)
 	resyncPeriod := time.Second * time.Duration(
-		v.Viper.GetInt("resync-period"))
+		v.Viper.GetInt("resync-period"),
+	)
 	wpaThraeds := v.Viper.GetInt("wpa-threads")
 	wpaDefaultMaxDisruption := v.Viper.GetString("wpa-default-max-disruption")
 	awsRegions := parseRegions(v.Viper.GetString("aws-regions"))
@@ -192,7 +198,8 @@ func (v *runCmd) run(cmd *cobra.Command, args []string) {
 		kubeInformerFactory.Apps().V1().ReplicaSets(),
 		customInformerFactory.K8s().V1().WorkerPodAutoScalers(),
 		wpaDefaultMaxDisruption,
-                resyncPeriod,
+		resyncPeriod,
+		scaleDownDelay,
 		queues,
 	)
 
@@ -210,7 +217,6 @@ func (v *runCmd) run(cmd *cobra.Command, args []string) {
 	if err = controller.Run(wpaThraeds, stopCh); err != nil {
 		klog.Fatalf("Error running controller: %s", err.Error())
 	}
-	return
 }
 
 func serveMetrics(metricsPort string) {

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -19,7 +19,6 @@ import (
 	"github.com/practo/k8s-worker-pod-autoscaler/pkg/signals"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	workerpodautoscalercontroller "github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
 	clientset "github.com/practo/k8s-worker-pod-autoscaler/pkg/generated/clientset/versioned"
@@ -102,7 +101,7 @@ func parseRegions(regionNames string) []string {
 
 func (v *runCmd) run(cmd *cobra.Command, args []string) {
 	scaleDownDelay := time.Second * time.Duration(
-		viper.GetInt("scale-down-delay-after-last-scale-activity"),
+		v.Viper.GetInt("scale-down-delay-after-last-scale-activity"),
 	)
 	resyncPeriod := time.Second * time.Duration(
 		v.Viper.GetInt("resync-period"),

--- a/cmd/workerpodautoscaler/run.go
+++ b/cmd/workerpodautoscaler/run.go
@@ -48,7 +48,7 @@ func (v *runCmd) new() *cobra.Command {
 	flags := v.Cmd.Flags()
 
 	flagNames := []string{
-		"scale-down-delay-after-scale-up",
+		"scale-down-delay-after-last-scale-activity",
 		"resync-period",
 		"wpa-threads",
 		"wpa-default-max-disruption",
@@ -65,7 +65,7 @@ func (v *runCmd) new() *cobra.Command {
 		"namespace",
 	}
 
-	flags.Int("scale-down-delay-after-scale-up", 600, "scale down delay after last scale up in seconds")
+	flags.Int("scale-down-delay-after-last-scale-activity", 600, "scale down delay after last scale up or down in seconds")
 	flags.Int("resync-period", 20, "sync period for the worker pod autoscaler")
 	flags.Int("wpa-threads", 10, "wpa threadiness, number of threads to process wpa resources")
 	flags.String("wpa-default-max-disruption", "100%", "it is the default value for the maxDisruption in the WPA spec. This specifies how much percentage of pods can be disrupted in a single scale down acitivity. Can be expressed as integers or as a percentage.")
@@ -102,7 +102,7 @@ func parseRegions(regionNames string) []string {
 
 func (v *runCmd) run(cmd *cobra.Command, args []string) {
 	scaleDownDelay := time.Second * time.Duration(
-		viper.GetInt("scale-down-delay-after-scale-up"),
+		viper.GetInt("scale-down-delay-after-last-scale-activity"),
 	)
 	resyncPeriod := time.Second * time.Duration(
 		v.Viper.GetInt("resync-period"),

--- a/pkg/apis/workerpodautoscaler/v1/types.go
+++ b/pkg/apis/workerpodautoscaler/v1/types.go
@@ -34,6 +34,12 @@ type WorkerPodAutoScalerStatus struct {
 	CurrentReplicas   int32 `json:"CurrentReplicas"`
 	AvailableReplicas int32 `json:"AvailableReplicas"`
 	DesiredReplicas   int32 `json:"DesiredReplicas"`
+
+	// LastScaleTime is the last time the WorkerPodAutoscaler scaled the workers
+	// It is used by the autoscaler to control
+	// how often the number of pods is changed.
+	// +optional
+	LastScaleTime *metav1.Time `json:"LastScaleTime,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -491,13 +491,13 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		queueName,
 	).Set(float64(availableWorkers))
 
-	lastScaleUpTime := workerPodAutoScaler.Status.LastScaleTime.DeepCopy()
+	lastScaleTime := workerPodAutoScaler.Status.LastScaleTime.DeepCopy()
 
 	op := GetScaleOperation(
 		queueName,
 		desiredWorkers,
 		currentWorkers,
-		lastScaleUpTime,
+		lastScaleTime,
 		c.scaleDownDelay,
 	)
 
@@ -513,7 +513,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		}
 
 		now := metav1.Now()
-		lastScaleUpTime = &now
+		lastScaleTime = &now
 	}
 
 	klog.V(2).Infof("%s scaleOp: %v", queueName, scaleOpString(op))
@@ -530,7 +530,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 		currentWorkers,
 		availableWorkers,
 		queueMessages,
-		lastScaleUpTime,
+		lastScaleTime,
 	)
 
 	loopDurationSeconds.WithLabelValues(
@@ -793,13 +793,13 @@ func updateWorkerPodAutoScalerStatus(
 	currentWorkers int32,
 	availableWorkers int32,
 	queueMessages int32,
-	lastScaleUpTime *metav1.Time) {
+	lastScaleTime *metav1.Time) {
 
 	if workerPodAutoScaler.Status.CurrentReplicas == currentWorkers &&
 		workerPodAutoScaler.Status.AvailableReplicas == availableWorkers &&
 		workerPodAutoScaler.Status.DesiredReplicas == desiredWorkers &&
 		workerPodAutoScaler.Status.CurrentMessages == queueMessages &&
-		workerPodAutoScaler.Status.LastScaleTime.Equal(lastScaleUpTime) {
+		workerPodAutoScaler.Status.LastScaleTime.Equal(lastScaleTime) {
 		klog.V(4).Infof("%s/%s: WPA status is already up to date\n", namespace, name)
 		return
 	} else {
@@ -814,7 +814,7 @@ func updateWorkerPodAutoScalerStatus(
 	workerPodAutoScalerCopy.Status.AvailableReplicas = availableWorkers
 	workerPodAutoScalerCopy.Status.DesiredReplicas = desiredWorkers
 	workerPodAutoScalerCopy.Status.CurrentMessages = queueMessages
-	workerPodAutoScalerCopy.Status.LastScaleTime = lastScaleUpTime
+	workerPodAutoScalerCopy.Status.LastScaleTime = lastScaleTime
 	// If the CustomResourceSubresources feature gate is not enabled,
 	// we must use Update instead of UpdateStatus to update the Status block of the WorkerPodAutoScaler resource.
 	// UpdateStatus will not allow changes to the Spec of the resource,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -511,9 +511,7 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 				ctx,
 				workerPodAutoScaler.Namespace, replicaSetName, &desiredWorkers)
 		}
-	}
 
-	if op == ScaleUp {
 		now := metav1.Now()
 		lastScaleUpTime = &now
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -199,6 +199,7 @@ func NewController(
 	replicaSetInformer appsinformers.ReplicaSetInformer,
 	workerPodAutoScalerInformer informers.WorkerPodAutoScalerInformer,
 	defaultMaxDisruption string,
+        resyncPeriod time.Duration,
 	queues *queue.Queues) *Controller {
 
 	// Create event broadcaster
@@ -230,13 +231,13 @@ func NewController(
 	klog.V(4).Info("Setting up event handlers")
 
 	// Set up an event handler for when WorkerPodAutoScaler resources change
-	workerPodAutoScalerInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	workerPodAutoScalerInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueAddWorkerPodAutoScaler,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueUpdateWorkerPodAutoScaler(new)
 		},
 		DeleteFunc: controller.enqueueDeleteWorkerPodAutoScaler,
-	})
+	}, resyncPeriod)
 	return controller
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -495,8 +495,8 @@ func (c *Controller) syncHandler(ctx context.Context, event WokerPodAutoScalerEv
 
 	op := GetScaleOperation(
 		queueName,
-		currentWorkers,
 		desiredWorkers,
+		currentWorkers,
 		lastScaleUpTime,
 		c.scaleDownDelay,
 	)

--- a/pkg/controller/scale_operation.go
+++ b/pkg/controller/scale_operation.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/practo/klog/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ScaleOperation int
+
+const (
+	ScaleUp ScaleOperation = iota
+	ScaleDown
+	ScaleNoop
+)
+
+func GetScaleOperation(
+	q string,
+	desiredWorkers int32,
+	currentWorkers int32,
+	lastScaleTime *metav1.Time,
+	scaleDownDelay time.Duration) ScaleOperation {
+
+	if desiredWorkers == currentWorkers {
+		return ScaleNoop
+	}
+
+	if desiredWorkers > currentWorkers {
+		return ScaleUp
+	}
+
+	if canScaleDown(
+		q, desiredWorkers, currentWorkers, lastScaleTime, scaleDownDelay) {
+		return ScaleDown
+	}
+
+	return ScaleNoop
+}
+
+// canScaleDown checks the scaleDownDelay and the lastScaleTime to decide
+// if scaling is required. Checks coolOff!
+func canScaleDown(
+	q string,
+	desiredWorkers int32,
+	currentWorkers int32,
+	lastScaleTime *metav1.Time, scaleDownDelay time.Duration) bool {
+
+	if lastScaleTime == nil {
+		klog.V(2).Infof("%s scaleDownDelay ignored, lastScaleTime is nil", q)
+		return true
+	}
+
+	nextScaleDownTime := metav1.NewTime(
+		lastScaleTime.Time.Add(scaleDownDelay),
+	)
+	now := metav1.Now()
+
+	if nextScaleDownTime.Before(&now) {
+		klog.V(2).Infof("%s scaleDown is allowed, cooloff passed", q)
+		return true
+	}
+
+	klog.V(2).Infof(
+		"%s scaleDown forbidden, nextScaleDownTime: %v",
+		q,
+		nextScaleDownTime,
+	)
+
+	return false
+}
+
+func scaleOpString(op ScaleOperation) string {
+	switch op {
+	case ScaleUp:
+		return "scale-up"
+	case ScaleDown:
+		return "scale-down"
+	case ScaleNoop:
+		return "no scaling operation"
+	default:
+		return ""
+	}
+}

--- a/pkg/controller/scale_operation.go
+++ b/pkg/controller/scale_operation.go
@@ -22,12 +22,12 @@ func GetScaleOperation(
 	lastScaleTime *metav1.Time,
 	scaleDownDelay time.Duration) ScaleOperation {
 
-	if desiredWorkers == currentWorkers {
-		return ScaleNoop
-	}
-
 	if desiredWorkers > currentWorkers {
 		return ScaleUp
+	}
+
+	if desiredWorkers == currentWorkers {
+		return ScaleNoop
 	}
 
 	if canScaleDown(

--- a/pkg/controller/scale_operation_test.go
+++ b/pkg/controller/scale_operation_test.go
@@ -1,0 +1,79 @@
+package controller_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/practo/k8s-worker-pod-autoscaler/pkg/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func timeBeforeSeconds(before int) *metav1.Time {
+	t := metav1.NewTime(time.Now().Add(
+		-time.Second * time.Duration(before)),
+	)
+
+	return &t
+}
+
+type opTestCase struct {
+	desired           int32
+	current           int32
+	scaleDownDelay    time.Duration
+	lastScaleTime     *metav1.Time
+	expectedOperation controller.ScaleOperation
+}
+
+func TestScaleOperation(t *testing.T) {
+	var opTestCases = []opTestCase{
+		{
+			current:           10,
+			desired:           5,
+			scaleDownDelay:    time.Second * time.Duration(5),
+			lastScaleTime:     timeBeforeSeconds(10),
+			expectedOperation: controller.ScaleDown,
+		},
+		{
+			current:           10,
+			desired:           5,
+			scaleDownDelay:    time.Second * time.Duration(5),
+			lastScaleTime:     timeBeforeSeconds(1),
+			expectedOperation: controller.ScaleNoop,
+		},
+		{
+			current:           10,
+			desired:           5,
+			scaleDownDelay:    time.Second * time.Duration(5),
+			lastScaleTime:     nil,
+			expectedOperation: controller.ScaleDown,
+		},
+		{
+			current:           10,
+			desired:           15,
+			scaleDownDelay:    time.Second * time.Duration(5),
+			lastScaleTime:     timeBeforeSeconds(1),
+			expectedOperation: controller.ScaleUp,
+		},
+		{
+			current:           10,
+			desired:           10,
+			scaleDownDelay:    time.Second * time.Duration(5),
+			lastScaleTime:     timeBeforeSeconds(1),
+			expectedOperation: controller.ScaleNoop,
+		},
+	}
+
+	for _, optc := range opTestCases {
+		tc := optc
+		op := controller.GetScaleOperation(
+			"q",
+			tc.desired,
+			tc.current,
+			tc.lastScaleTime,
+			tc.scaleDownDelay,
+		)
+		if op != tc.expectedOperation {
+			t.Errorf("expected op=%v, got=%v", tc.expectedOperation, op)
+		}
+	}
+}


### PR DESCRIPTION
**Why?** https://github.com/practo/k8s-worker-pod-autoscaler/issues/143#issuecomment-1034553172

**What?** Adds `scale-down-delay-after-last-scale-activity.`
```
--scale-down-delay-after-last-scale-activity 
scale down delay after last scale up or down (defaults to 600 seconds i.e 10mins)
```

Fixes https://github.com/practo/k8s-worker-pod-autoscaler/issues/143


![Screenshot 2022-02-16 at 8 07 05 PM](https://user-images.githubusercontent.com/9006763/154287026-61ba5ab7-e96f-4d0f-b939-75ef9bc4fdd7.png)

