### PR TITLE
Remove Dockerhub and use only Public ECR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script:
 - make build
 - test -f bin/linux_amd64/workerpodautoscaler
 - make all-container
-- docker images | grep "^practodev/workerpodautoscaler"
+- docker images | grep "^public.ecr.aws/practo/workerpodautoscaler"
 - make test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN := workerpodautoscaler
 UNIQUE:=$(shell date +%s)
 
 # Where to push the docker image.
-REGISTRY ?= practodev
+REGISTRY ?= public.ecr.aws/practo
 
 BASE_BRANCH := master
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -61,7 +61,7 @@ define \n
 endef
 
 BUILD_IMAGE ?= golang:1.17.1-alpine
-TEST_IMAGE ?= practodev/golang:1.17.1-alpine-test
+TEST_IMAGE ?= public.ecr.aws/practo/golang:1.17.1-alpine-test
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ git pull origin master
 
 ```
 
-- Build and push the image to `hub.docker.com/practodev` or `public.ecr.aws/practo`. Note: dokcerhub or ECR push access is required or use a custom registry by adding `REGISTRY=public.ecr.aws/exampleorg make push`
+- Build and push the image to `public.ecr.aws/practo`. Note: ECR push access is required or use a custom registry by adding `REGISTRY=public.ecr.aws/exampleorg make push`
 ```
 git fetch --tags
 git tag v1.6.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,7 +19,7 @@ None
 - [v1.5.0](https://github.com/practo/k8s-worker-pod-autoscaler/releases/tag/v1.5.0)
 
 ## Upgrade from v1.3 to v1.4
-Updates all the kubernetes dependencies with `v1.20`. It should work for the cluster with older versions as well. Also with this release images are available in prato's public ECR as `public.ecr.aws/practo/workerpodautoscaler:v1.3.0`. Default is still practodev.
+Updates all the kubernetes dependencies with `v1.20`. It should work for the cluster with older versions as well. Also with this release images are available in practo's public ECR as `public.ecr.aws/practo/workerpodautoscaler:v1.3.0`.
 
 ### Breaking changes
 None

--- a/artifacts/deployment-template.yaml
+++ b/artifacts/deployment-template.yaml
@@ -28,7 +28,7 @@ spec:
          value: {{ WPA_AWS_ACCESS_KEY_ID }}
        - name: AWS_SECRET_ACCESS_KEY
          value: {{ WPA_AWS_SECRET_ACCESS_KEY }}
-       image: practodev/workerpodautoscaler:{{ WPA_TAG }}
+       image: public.ecr.aws/practo/workerpodautoscaler:{{ WPA_TAG }}
        imagePullPolicy: Always
        command:
        - /workerpodautoscaler

--- a/artifacts/golang/README.md
+++ b/artifacts/golang/README.md
@@ -2,7 +2,7 @@
 
 Test image used for `make test`.
 
-Current image being used: `practodev/golang:1.17.1-alpine-test`
+Current image being used: `public.ecr.aws/practo/golang:1.17.1-alpine-test`
 
 ### Why?
 It keeps all the test dependencies installed on top of golang package
@@ -10,5 +10,5 @@ It keeps all the test dependencies installed on top of golang package
 ### Built using
 ```
 cd 1.17.1-alpine-test
-docker build -t practodev/golang:1.17.1-alpine-test .
+docker build -t public.ecr.aws/practo/golang:1.17.1-alpine-test .
 ```

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -23,7 +23,7 @@ export WPA_AWS_REGIONS="${AWS_REGIONS}"
 export WPA_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
 export WPA_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
 
-echo "Image to be used: practodev/${WPA_TAG}"
+echo "Image to be used: public.ecr.aws/practo/${WPA_TAG}"
 
 cp -f $template_deployment $new_deployment
 ./hack/generate.sh ${new_deployment}


### PR DESCRIPTION
As we are removing practodev organization from Dockerhub, removing all references and usage. Only AWS Public ECR is to be used going forward.